### PR TITLE
solve: 119. Pascal's Triangle II

### DIFF
--- a/leet-code/js/lc-119-pascals-triangle-ii.js
+++ b/leet-code/js/lc-119-pascals-triangle-ii.js
@@ -1,0 +1,19 @@
+/**
+ * @param {number} rowIndex
+ * @return {number[]}
+ */
+var getRow = function (rowIndex) {
+  const row = [];
+
+  while (row.length < rowIndex + 1) {
+    const previousRow = [...row];
+
+    for (let i = 1; i < row.length; i++) {
+      row[i] = previousRow[i] + previousRow[i - 1];
+    }
+
+    row[row.length] = 1;
+  }
+
+  return row;
+};


### PR DESCRIPTION
Runtime: 70 ms, faster than 76.18% of JavaScript online submissions for Pascal's Triangle II.
Memory Usage: 41.9 MB, less than 78.94% of JavaScript online submissions for Pascal's Triangle II.